### PR TITLE
Fix duplicate output directory declaration in sass compile task

### DIFF
--- a/plugin/src/main/java/org/kravemir/gradle/sass/SassCompileTask.java
+++ b/plugin/src/main/java/org/kravemir/gradle/sass/SassCompileTask.java
@@ -47,7 +47,7 @@ public class SassCompileTask extends AbstractSassCompileTask {
         this.srcDir = srcDir;
     }
 
-    @OutputDirectory
+    @Internal
     public File getOutDir() {
         return outDir != null ? outDir : Paths.get(getProject().getBuildDir().getPath(), "sass", sassSetName).toFile();
     }


### PR DESCRIPTION
- Fixes deprecation warning with gradle 6.0

The added functional test demos the fix. Without this change this plugin throws a deprecation warning when output of the sass compile task is used as input in any archive task like copy, sync etc.